### PR TITLE
feat: add multiple faces to same album in 1 run

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -30,7 +30,7 @@ immich-face-to-album --key xxxxx --server https://your-immich-instance.com --fac
 
 Make sure to specify the protocol and port in the server url. For example, if your server is running on port 8080, you should specify the url as `http://your-server-url:8080`.
 
-You can run the command multiple times to add different faces to the same album.
+You can repeat the `--face` multiple times to add multiple faces to the same album.
 
 
 ### On a schedule

--- a/immich_face_to_album/__main__.py
+++ b/immich_face_to_album/__main__.py
@@ -110,7 +110,12 @@ def chunker(seq, size):
 @click.command()
 @click.option("--key", help="Your Immich API Key", required=True)
 @click.option("--server", help="Your Immich server URL", required=True)
-@click.option("--face", help="ID of the face you want to copy from", required=True)
+@click.option(
+    "--face",
+    help="ID of the face you want to copy from. Can be used multiple times.",
+    multiple=True,
+    required=True,
+)
 @click.option("--album", help="ID of the album you want to copy to", required=True)
 @click.option(
     "--timebucket", help="Time bucket size (e.g., MONTH, WEEK)", default="MONTH"
@@ -119,15 +124,20 @@ def chunker(seq, size):
 def face_to_album(key, server, face, album, timebucket, verbose):
     headers = {"Accept": "application/json", "x-api-key": key}
 
-    time_buckets = get_time_buckets(server, key, face, timebucket, verbose)
-
     unique_asset_ids = set()
-    for bucket in time_buckets:
-        bucket_time = bucket.get("timeBucket")
-        bucket_assets = get_assets_for_time_bucket(
-            server, key, face, bucket_time, timebucket, verbose
-        )
-        unique_asset_ids.update(bucket_assets["id"])
+
+    for face_id in face:
+        if verbose:
+            click.echo(f"Processing face ID: {face_id}")
+
+        time_buckets = get_time_buckets(server, key, face_id, timebucket, verbose)
+
+        for bucket in time_buckets:
+            bucket_time = bucket.get("timeBucket")
+            bucket_assets = get_assets_for_time_bucket(
+                server, key, face_id, bucket_time, timebucket, verbose
+            )
+            unique_asset_ids.update(bucket_assets["id"])
 
     click.echo(f"Total unique assets to add: {len(unique_asset_ids)}")
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name="immich-face-to-album",
     packages=["immich_face_to_album"],
-    version="1.0.6",
+    version="1.0.7",
     license="WTFPL",
     description='Tool to import a user\'s face from Immich into an album, mimicking the Google Photos "auto-updating album" feature.',
     long_description="""
@@ -31,7 +31,7 @@ immich-face-to-album --key xxxxx --server https://your-immich-instance.com --fac
 
 Make sure to specify the protocol and port in the server url. For example, if your server is running on port 8080, you should specify the url as `http://your-server-url:8080`.
 
-You can run the command multiple times to add different faces to the same album.
+You can repeat the `--face` multiple times to add multiple faces to the same album.
 
 
 ### On a schedule


### PR DESCRIPTION
This allows `--face` to be used multiple times to add multiple faces to the same album without having to repeat the command for each of them.

e.g.:

```bash
immich-face-to-album --key xxxxx --server https://your-immich-instance.com --face xxxxx --face yyyyy --face zzzzz  --album aaaaa
```

This will add face `xxxxx`, `yyyyy` and `zzzzz` to album `aaaaa`.