### PR TITLE
fix: use metadata search for album asset listing (Immich v3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ htmlcov/
 coverage.xml
 __pycache__/
 *.pyc
+# uv
+uv.lock
+.venv/

--- a/immich_face_to_album/__main__.py
+++ b/immich_face_to_album/__main__.py
@@ -104,35 +104,54 @@ def get_asset(server_url, key, asset_id, verbose=False):
 
 
 def get_album_assets(server_url, key, album_id, verbose=False):
-   """
-   Fetch all assets currently present in the album.
-   Returns a set of asset IDs (as strings).
-   """
-   url = f"{server_url}/api/albums/{album_id}"
-   headers = {"x-api-key": key, "Accept": "application/json"}
+    """
+    Fetch all asset IDs currently present in the album.
 
-   if verbose:
-       click.echo(f"Fetching album info from {url}")
+    Immich v3 removed the `assets` property from AlbumResponseDto, so
+    GET /api/albums/{id} no longer returns its assets. Page through the
+    metadata search endpoint (POST /api/search/metadata) instead.
+    Returns a set of asset IDs (as strings).
+    """
+    url = f"{server_url}/api/search/metadata"
+    headers = {
+        "x-api-key": key,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
 
-   response = requests.get(url, headers=headers)
+    asset_ids = set()
+    page = 1
+    while True:
+        payload = json.dumps({"albumIds": [album_id], "page": page, "size": 1000})
 
-   if response.status_code != 200:
-       click.echo(
-           click.style(
-               f"Failed to fetch album info. Status code: {response.status_code}, Response text: {response.text}",
-               fg="red",
-           )
-       )
-       return set()
+        if verbose:
+            click.echo(f"Fetching album assets from {url} (page {page})")
 
-   album_data = response.json()
-   asset_objs = album_data.get("assets", []) or []
-   asset_ids = {str(a.get("id")) for a in asset_objs if a.get("id")}
+        response = requests.post(url, headers=headers, data=payload)
 
-   if verbose:
-       click.echo(f"Album currently contains {len(asset_ids)} asset(s)")
+        if response.status_code != 200:
+            click.echo(
+                click.style(
+                    f"Failed to fetch album assets. Status code: {response.status_code}, Response text: {response.text}",
+                    fg="red",
+                )
+            )
+            return set()
 
-   return asset_ids
+        assets = response.json().get("assets", {}) or {}
+        for a in assets.get("items", []):
+            if a.get("id"):
+                asset_ids.add(str(a.get("id")))
+
+        next_page = assets.get("nextPage")
+        if not next_page:
+            break
+        page = int(next_page)
+
+    if verbose:
+        click.echo(f"Album currently contains {len(asset_ids)} asset(s)")
+
+    return asset_ids
 
 
 def remove_assets_from_album(server_url, key, album_id, asset_ids, verbose=False):

--- a/tests/test_api_functions.py
+++ b/tests/test_api_functions.py
@@ -411,15 +411,17 @@ class TestAlbumFunctions:
     """Test album-related API functions (list and remove)."""
 
     def test_get_album_assets_success(self):
-        """Test fetching album assets succeeds and returns IDs as strings."""
+        """Test fetching album assets via metadata search returns IDs as strings."""
         with requests_mock.Mocker() as m:
-            album_payload = {
-                "id": "album-123",
-                "assets": [{"id": "asset-1"}, {"id": "asset-3"}],
+            search_payload = {
+                "assets": {
+                    "items": [{"id": "asset-1"}, {"id": "asset-3"}],
+                    "nextPage": None,
+                }
             }
-            m.get(
-                "https://example.com/api/albums/album-123",
-                json=album_payload,
+            m.post(
+                "https://example.com/api/search/metadata",
+                json=search_payload,
                 status_code=200,
             )
 
@@ -430,6 +432,35 @@ class TestAlbumFunctions:
             assert isinstance(result, set)
             assert result == {"asset-1", "asset-3"}
             assert m.last_request.headers["x-api-key"] == "test-key"
+            assert m.last_request.json() == {
+                "albumIds": ["album-123"],
+                "page": 1,
+                "size": 1000,
+            }
+
+    def test_get_album_assets_paginates(self):
+        """Test that pagination follows nextPage until exhausted."""
+        with requests_mock.Mocker() as m:
+            m.post(
+                "https://example.com/api/search/metadata",
+                [
+                    {
+                        "json": {"assets": {"items": [{"id": "asset-1"}], "nextPage": "2"}},
+                        "status_code": 200,
+                    },
+                    {
+                        "json": {"assets": {"items": [{"id": "asset-2"}], "nextPage": None}},
+                        "status_code": 200,
+                    },
+                ],
+            )
+
+            result = get_album_assets(
+                "https://example.com", "test-key", "album-123", False
+            )
+
+            assert result == {"asset-1", "asset-2"}
+            assert m.call_count == 2
 
     def test_remove_assets_from_album_success(self, capsys):
         """Test removal of assets from an album using the DELETE endpoint."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1012,10 +1012,15 @@ class TestRemoveNonMatching:
             status_code=200,
         )
 
-        # Mock current album info containing asset-1 and asset-2
-        mock_api.get(
-            "https://example.com/api/albums/album-123",
-            json={"id": "album-123", "assets": [{"id": "asset-1"}, {"id": "asset-2"}]},
+        # Mock current album assets (metadata search) containing asset-1 and asset-2
+        mock_api.post(
+            "https://example.com/api/search/metadata",
+            json={
+                "assets": {
+                    "items": [{"id": "asset-1"}, {"id": "asset-2"}],
+                    "nextPage": None,
+                }
+            },
             status_code=200,
         )
 


### PR DESCRIPTION
## What

`get_album_assets` read the `assets` property from `GET /api/albums/{id}`. Immich v3 removed that property from `AlbumResponseDto`, so the call now returns an album object with no assets.

This only affects the `--remove-non-matching` path, and it fails quietly. `get_album_assets` returns an empty set, so `current_assets - desired_assets` is always empty and nothing gets removed. No error, no crash, the flag just stops working.

The main add-to-album flow was unaffected. The timeline, asset, and album-mutation endpoints the tool relies on are unchanged in v3.

## Change

Fetch the album's current assets by paging through `POST /api/search/metadata` with an `albumIds` filter, following `nextPage` until it's null. Request and response shapes confirmed against the v3 OpenAPI spec.

## Tests

- Updated `test_get_album_assets_success` and the `--remove-non-matching` CLI test to mock the metadata search endpoint.
- Added `test_get_album_assets_paginates` to cover the `nextPage` loop.
- Full suite: 48 passed.

Ref: [Migrating to v3](https://immich.app/blog/v3-migration) (AlbumResponseDto).
